### PR TITLE
fix: モバイルスワイプ機能の表示問題を修正

### DIFF
--- a/script.js
+++ b/script.js
@@ -33,7 +33,16 @@ document.addEventListener('DOMContentLoaded', function() {
       return;
     }
     
-    console.log(`goToSection: Moving to section ${sectionIndex}`);
+    console.log(`goToSection: Moving to section ${sectionIndex} of ${sections.length}`);
+    
+    // Debug: Log current section info
+    const targetSection = sections[sectionIndex];
+    if (targetSection) {
+      console.log(`goToSection: Target section classes:`, targetSection.className);
+      console.log(`goToSection: Target section has content:`, targetSection.innerHTML.length > 0);
+      console.log(`goToSection: Target section computed style:`, window.getComputedStyle(targetSection).backgroundColor);
+    }
+    
     currentSection = Math.max(0, Math.min(sectionIndex, sections.length - 1));
     const translateX = -currentSection * 100;
     console.log(`goToSection: translateX = ${translateX}vw`);
@@ -45,10 +54,27 @@ document.addEventListener('DOMContentLoaded', function() {
       dot.classList.toggle('active', index === currentSection);
     });
     
+    // Debug: Log current transform and section visibility
+    console.log(`goToSection: Container transform applied:`, swipeContainer.style.transform);
+    console.log(`goToSection: Current section ${currentSection} is visible`);
+    
     // Hide swipe hint after first interaction
     if (swipeHint && currentSection > 0) {
       swipeHint.style.display = 'none';
     }
+    
+    // Debug: Force visibility check for current section
+    setTimeout(() => {
+      const currentSectionElement = sections[currentSection];
+      if (currentSectionElement) {
+        console.log(`goToSection: Section ${currentSection} final visibility check:`, {
+          display: window.getComputedStyle(currentSectionElement).display,
+          opacity: window.getComputedStyle(currentSectionElement).opacity,
+          backgroundColor: window.getComputedStyle(currentSectionElement).backgroundColor,
+          height: window.getComputedStyle(currentSectionElement).height
+        });
+      }
+    }, 100);
   }
   
   // Touch event handling for swipe
@@ -124,15 +150,37 @@ document.addEventListener('DOMContentLoaded', function() {
   // Initialize mobile swipe if on mobile device
   if (isMobile && swipeContainer) {
     console.log('Initializing mobile swipe functionality...');
+    console.log('Debug: Found', sections.length, 'mobile sections:');
+    
+    // Debug: Log all sections
+    sections.forEach((section, index) => {
+      console.log(`  Section ${index}:`, {
+        id: section.id,
+        classes: section.className,
+        hasContent: section.innerHTML.length > 0,
+        clientHeight: section.clientHeight,
+        backgroundColor: window.getComputedStyle(section).backgroundColor
+      });
+    });
+    
     initMobileNavigation();
     
     // Set initial position
     swipeContainer.style.transform = 'translateX(0vw)';
+    console.log('Debug: Initial transform set to translateX(0vw)');
+    
+    // Debug: Check container setup
+    console.log('Debug: Swipe container setup:', {
+      width: swipeContainer.clientWidth,
+      height: swipeContainer.clientHeight,
+      childrenCount: swipeContainer.children.length
+    });
     
     // Add touch event listeners
     swipeContainer.addEventListener('touchstart', handleTouchStart, { passive: false });
     swipeContainer.addEventListener('touchmove', handleTouchMove, { passive: false });
     swipeContainer.addEventListener('touchend', handleTouchEnd, { passive: false });
+    console.log('Debug: Touch event listeners added');
     
     // Add keyboard event listener
     document.addEventListener('keydown', handleKeyDown);
@@ -146,6 +194,10 @@ document.addEventListener('DOMContentLoaded', function() {
         }, 500);
       }
     }, 5000);
+    
+    console.log('Debug: Mobile swipe initialization complete');
+  } else {
+    console.log('Debug: Mobile swipe not initialized:', { isMobile, hasSwipeContainer: !!swipeContainer });
   }
 
   // Smooth scrolling for internal links (modified for mobile swipe)

--- a/style.css
+++ b/style.css
@@ -1820,12 +1820,63 @@ h4 {
     overflow-x: hidden;
     padding: 40px 0 120px 0;
     box-sizing: border-box;
+    background-color: #ffffff;
   }
   
   .mobile-section.hero {
     height: 100vh;
     justify-content: center;
     padding: 0;
+  }
+  
+  /* Ensure gradient backgrounds apply to mobile sections */
+  .mobile-section.section-padding-gradient,
+  .mobile-section .section-padding-gradient {
+    background: var(--bg-gradient);
+    color: var(--light-text-color);
+    position: relative;
+    overflow: hidden;
+  }
+  
+  .mobile-section.section-padding-gradient::before,
+  .mobile-section .section-padding-gradient::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><defs><pattern id="grain" width="100" height="100" patternUnits="userSpaceOnUse"><circle cx="50" cy="50" r="0.5" fill="%23ffffff" opacity="0.1"/></pattern></defs><rect width="100" height="100" fill="url(%23grain)"/></svg>') repeat;
+    pointer-events: none;
+  }
+  
+  /* Fix fade-in animation for mobile - ensure content is visible by default */
+  .mobile-section .fade-in {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  
+  /* Override fade-in for mobile sections to ensure immediate visibility */
+  .mobile-section .hero-content,
+  .mobile-section .problem-item,
+  .mobile-section .benefit-item,
+  .mobile-section .result-item,
+  .mobile-section .feature-item,
+  .mobile-section .casestudy-item,
+  .mobile-section .process-step,
+  .mobile-section .pricing-plan,
+  .mobile-section .faq-item {
+    opacity: 1 !important;
+    transform: translateY(0) !important;
+  }
+  
+  /* Ensure all content areas have proper flex settings and visibility */
+  .mobile-section .container {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    z-index: 2;
+    position: relative;
   }
   
   /* Hide footer on mobile swipe layout */


### PR DESCRIPTION
Resolves #issue-9

## Summary
Fixed mobile swipe functionality where pages 2+ were showing blank/white screens.

## Changes
- Added default white background to mobile sections
- Fixed gradient background inheritance for .section-padding-gradient
- Overrode fade-in animations for immediate visibility on mobile
- Enhanced content layout and visibility settings
- Added debug logging for troubleshooting

## Test Plan
- [ ] Test mobile swipe functionality on device/emulator
- [ ] Verify all 11 pages display correctly
- [ ] Check gradient backgrounds are applied properly
- [ ] Confirm content is visible on all sections

🤖 Generated with [Claude Code](https://claude.ai/code)